### PR TITLE
link_to　修正

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -22,7 +22,7 @@
                 = link_to "My Page", user_path(current_user)
           %li
             .btn.btn-primary.navbar-btn
-              = link_to "New Proto", prototypes_new_path
+              = link_to "New Proto", new_prototype_path
       -else
         %ul.nav.navbar-nav.navbar-right
           %li


### PR DESCRIPTION
# WHAT

resourcesによって生じたlink_toのpathのエラーを修正
# WHY

indexの正常な表示
# 実装手順
1. _header.html.hamlのlink_toのpathを変更
# 期限

9/20
