### PR TITLE
プロトタイプ投稿機能実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -4,14 +4,19 @@ class PrototypesController < ApplicationController
 
   def new
     @prototype = Prototype.new
+    @main_content = @prototype.prototype_images.build
   end
 
   def create
-    Prototype.create(prototype_params)
+    @main_content.save
     redirect_to action: :index
   end
 
   def prototype_params
-    params.permit(:title, :text, :catchcopy, :concept)
+    params.require(:prototype).permit(:title, :text, :catchcopy, :concept).merge(user_id: current_user.id)
+  end
+
+  def prototype_image_params
+    params.require(:prototype_image).permit(:content, :role).merge(prototype_id: params[:prototype_id])
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -15,6 +15,6 @@ class PrototypesController < ApplicationController
 
   private
   def prototype_params
-    params.require(:prototype).permit(:title, :text, :catchcopy, :concept, prototype_images_attributes: [:content, :role]).merge(user_id: current_user.id)
+    params.require(:prototype).permit(:id, :title, :text, :catchcopy, :concept, prototype_images_attributes: [:id, :content, :role]).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -8,15 +8,13 @@ class PrototypesController < ApplicationController
   end
 
   def create
-    @main_content.save
+    prototype = Prototype.new(prototype_params)
+    prototype.save
     redirect_to action: :index
   end
 
+  private
   def prototype_params
-    params.require(:prototype).permit(:title, :text, :catchcopy, :concept).merge(user_id: current_user.id)
-  end
-
-  def prototype_image_params
-    params.require(:prototype_image).permit(:content, :role).merge(prototype_id: params[:prototype_id])
+    params.require(:prototype).permit(:title, :text, :catchcopy, :concept, prototype_images_attributes: [:content, :role]).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,17 @@
 class PrototypesController < ApplicationController
   def index
   end
+
+  def new
+    @prototype = Prototype.new
+  end
+
+  def create
+    Prototype.create(prototype_params)
+    redirect_to action: :index
+  end
+
+  def prototype_params
+    params.permit(:title, :text, :catchcopy, :concept)
+  end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -10,6 +10,7 @@ class PrototypesController < ApplicationController
   def create
     prototype = Prototype.new(prototype_params)
     prototype.save
+    flash[:notice] = "投稿が完了しました"
     redirect_to action: :index
   end
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -4,7 +4,7 @@ class PrototypesController < ApplicationController
 
   def new
     @prototype = Prototype.new
-    @main_content = @prototype.prototype_images.build
+    @prototype.prototype_images.build
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.permit(:email, :password, :username, :member, :profile, :work, :image)
+    params.permit(:email, :password, :username, :member, :profile, :work, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,2 +1,4 @@
 class Prototype < ActiveRecord::Base
+  belongs_to :user
+  has_many :prototype_images
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,5 +1,5 @@
 class Prototype < ActiveRecord::Base
   belongs_to :user
   has_many :prototype_images
-  accepts_nested_attributes_for :prototype_images
+  accepts_nested_attributes_for :prototype_images, allow_destroy: true, reject_if: proc { |attributes| attributes['content'].blank? }
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,4 +1,5 @@
 class Prototype < ActiveRecord::Base
   belongs_to :user
   has_many :prototype_images
+  accepts_nested_attributes_for :prototype_images
 end

--- a/app/models/prototype_image.rb
+++ b/app/models/prototype_image.rb
@@ -1,4 +1,5 @@
 class PrototypeImage < ActiveRecord::Base
   enum role: %i(main sub)
   belongs_to :prototype
+  mount_uploader :content, ImageUploader
 end

--- a/app/models/prototype_image.rb
+++ b/app/models/prototype_image.rb
@@ -1,0 +1,4 @@
+class PrototypeImage < ActiveRecord::Base
+  enum role: %i(main sub)
+  belongs_to :prototype
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,5 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   mount_uploader :image, ImageUploader
+  has_many :prototypes
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -20,9 +20,10 @@
                 = link_to "Log out", destroy_user_session_path, method: :delete
               %li
                 = link_to "My Page", user_path(current_user)
-          %li
-            .btn.btn-primary.navbar-btn
-              = link_to "New Proto", new_prototype_path
+          = if user_signed_in?
+            %li
+              .btn.btn-primary.navbar-btn
+                = link_to "New Proto", new_prototype_path
       -else
         %ul.nav.navbar-nav.navbar-right
           %li

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -20,7 +20,6 @@
                 = link_to "Log out", destroy_user_session_path, method: :delete
               %li
                 = link_to "My Page", user_path(current_user)
-          = if user_signed_in?
             %li
               .btn.btn-primary.navbar-btn
                 = link_to "New Proto", new_prototype_path

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -20,9 +20,9 @@
                 = link_to "Log out", destroy_user_session_path, method: :delete
               %li
                 = link_to "My Page", user_path(current_user)
-            %li
-              .btn.btn-primary.navbar-btn
-                = link_to "New Proto", new_prototype_path
+          %li
+            .btn.btn-primary.navbar-btn
+              = link_to "New Proto", new_prototype_path
       -else
         %ul.nav.navbar-nav.navbar-right
           %li

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -15,12 +15,14 @@
             %ul.proto-sub-list.list-group
               %li.list-group-item.col-md-4
                 .image-upload
-                  = image.hidden_field :role, {value: 'sub'}
-                  = image.file_field :content, role: :sub
+                  = f.fields_for :prototype_images do |image|
+                    = image.hidden_field :role, {value: 'sub'}
+                    = image.file_field :content, role: :sub
               %li.list-group-item.col-md-4
                 .image-upload
-                  = image.hidden_field :role, {value: 'sub'}
-                  = image.file_field :content, role: :sub
+                  = f.fields_for :prototype_images do |image|
+                    = image.hidden_field :role, {value: 'sub'}
+                    = image.file_field :content, role: :sub
               %li.list-group-item.col-md-4
                 .image-upload-plus
                   %span +

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -6,17 +6,20 @@
           .proto-new-title
             = f.text_area :title, placeholder: "Title", class: "proto-new-title"
       .row
-        = fields_for :prototype_images do |image|
+        = f.fields_for :prototype_images do |image|
           .col-md-12
             .cover-image-upload
-              = image.file_field :content, role: :main
+              = image.hidden_field :role, {value: 'main'}
+              = image.file_field :content, role: 0
           .col-md-12
             %ul.proto-sub-list.list-group
               %li.list-group-item.col-md-4
                 .image-upload
+                  = image.hidden_field :role, {value: 'sub'}
                   = image.file_field :content, role: :sub
               %li.list-group-item.col-md-4
                 .image-upload
+                  = image.hidden_field :role, {value: 'sub'}
                   = image.file_field :content, role: :sub
               %li.list-group-item.col-md-4
                 .image-upload-plus

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -6,18 +6,19 @@
           .proto-new-title
             = f.text_area :title, placeholder: "Title", class: "proto-new-title"
       .row
-        = f.fields_for :prototype_images do |image|
-          .col-md-12
-            .cover-image-upload
-              = image.hidden_field :role, {value: 'main'}
+        .col-md-12
+          .cover-image-upload
+            = f.fields_for :prototype_images do |image|
+              = image.hidden_field :role, value: :main
               = image.file_field :content
           .col-md-12
             %ul.proto-sub-list.list-group
               - 2.times do
                 %li.list-group-item.col-md-4
                   .image-upload
-                    = image.hidden_field :role, {value: 'sub'}
-                    = image.file_field :content
+                    = f.fields_for :prototype_images do |image|
+                      = image.hidden_field :role, value: :sub
+                      = image.file_field :content
               %li.list-group-item.col-md-4
                 .image-upload-plus
                   %span +

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -6,18 +6,18 @@
           .proto-new-title
             = f.text_area :title, placeholder: "Title", class: "proto-new-title"
       .row
-        = fields_for(@main_content) do |main|
+        = fields_for :prototype_images do |image|
           .col-md-12
             .cover-image-upload
-              = main.file_field :content, role: :main
+              = image.file_field :content, role: :main
           .col-md-12
             %ul.proto-sub-list.list-group
               %li.list-group-item.col-md-4
                 .image-upload
-                  %input{type: "file"}/
+                  = image.file_field :content, role: :sub
               %li.list-group-item.col-md-4
                 .image-upload
-                  %input{type: "file"}/
+                  = image.file_field :content, role: :sub
               %li.list-group-item.col-md-4
                 .image-upload-plus
                   %span +

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -10,19 +10,14 @@
           .col-md-12
             .cover-image-upload
               = image.hidden_field :role, {value: 'main'}
-              = image.file_field :content, role: 0
+              = image.file_field :content
           .col-md-12
             %ul.proto-sub-list.list-group
-              %li.list-group-item.col-md-4
-                .image-upload
-                  = f.fields_for :prototype_images do |image|
+              - 2.times do
+                %li.list-group-item.col-md-4
+                  .image-upload
                     = image.hidden_field :role, {value: 'sub'}
-                    = image.file_field :content, role: :sub
-              %li.list-group-item.col-md-4
-                .image-upload
-                  = f.fields_for :prototype_images do |image|
-                    = image.hidden_field :role, {value: 'sub'}
-                    = image.file_field :content, role: :sub
+                    = image.file_field :content
               %li.list-group-item.col-md-4
                 .image-upload-plus
                   %span +

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -1,36 +1,38 @@
-%form.container.proto-new{action: ""}
-  .col-md-8.col-md-offset-2
-    %header.row.user-nav.row
-      .col-md-12
-        %input.proto-new-title{type: "text", placeholder: "Title"}/
-    .row
-      .col-md-12
-        .cover-image-upload
-          %input{type: "file"}/
-      .col-md-12
-        %ul.proto-sub-list.list-group
-          %li.list-group-item.col-md-4
-            .image-upload
-              %input{type: "file"}/
-          %li.list-group-item.col-md-4
-            .image-upload
-              %input{type: "file"}/
-          %li.list-group-item.col-md-4
-            .image-upload-plus
-              %span +
-    .row.proto-description
-      .col-md-12
-        %input{type: "text", placeholder: "Catch Copy"}/
-      .col-md-12
-        %textarea{name: "", cols: "30", rows: "4", placeholder: "Concept"}
-      .col-md-12
-        %h4 Tag List
-        .row
-          .col-md-3
-            %input{type: "text", placeholder: "Web Design"}/
-          .col-md-3
-            %input{type: "text", placeholder: "UI"}/
-          .col-md-3
-            %input{type: "text", placeholder: "Application"}/
-    .row.text-center.proto-btn
-      %button.btn.btn-lg.btn-primary.btn-block{type: "submit"} Publish
+.conrainer.proto-new
+  = form_for @prototype do |f|
+    .col-md-8.col-md-offset-2
+      %header.row.user-nav.row
+        .col-md-12
+          .proto-new-title
+            = f.text_area :title, placeholder: "Title", class: "proto-new-title"
+      .row
+        .col-md-12
+          .cover-image-upload
+            %input{type: "file"}/
+        .col-md-12
+          %ul.proto-sub-list.list-group
+            %li.list-group-item.col-md-4
+              .image-upload
+                %input{type: "file"}/
+            %li.list-group-item.col-md-4
+              .image-upload
+                %input{type: "file"}/
+            %li.list-group-item.col-md-4
+              .image-upload-plus
+                %span +
+      .row.proto-description
+        .col-md-12
+          = f.text_area :catchcopy, placeholder: "Catch Copy"
+        .col-md-12
+          = f.text_area :concept, cols: "30", rows: "4", placeholder: "Concept"
+        .col-md-12
+          %h4 Tag List
+          .row
+            .col-md-3
+              %input{type: "text", placeholder: "Web Design"}/
+            .col-md-3
+              %input{type: "text", placeholder: "UI"}/
+            .col-md-3
+              %input{type: "text", placeholder: "Application"}/
+      .row.text-center.proto-btn
+        = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -6,20 +6,21 @@
           .proto-new-title
             = f.text_area :title, placeholder: "Title", class: "proto-new-title"
       .row
-        .col-md-12
-          .cover-image-upload
-            %input{type: "file"}/
-        .col-md-12
-          %ul.proto-sub-list.list-group
-            %li.list-group-item.col-md-4
-              .image-upload
-                %input{type: "file"}/
-            %li.list-group-item.col-md-4
-              .image-upload
-                %input{type: "file"}/
-            %li.list-group-item.col-md-4
-              .image-upload-plus
-                %span +
+        = fields_for(@main_content) do |main|
+          .col-md-12
+            .cover-image-upload
+              = main.file_field :content, role: :main
+          .col-md-12
+            %ul.proto-sub-list.list-group
+              %li.list-group-item.col-md-4
+                .image-upload
+                  %input{type: "file"}/
+              %li.list-group-item.col-md-4
+                .image-upload
+                  %input{type: "file"}/
+              %li.list-group-item.col-md-4
+                .image-upload-plus
+                  %span +
       .row.proto-description
         .col-md-12
           = f.text_area :catchcopy, placeholder: "Catch Copy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'prototypes#index'
-  resources :prototypes, only: [:index, :new, :show]
+  resources :prototypes, only: [:index, :new, :show, :create]
   resources :users, only: [:show, :edit, :update]
 end

--- a/db/migrate/20160924135213_add_user_id_to_prototype.rb
+++ b/db/migrate/20160924135213_add_user_id_to_prototype.rb
@@ -1,0 +1,5 @@
+class AddUserIdToPrototype < ActiveRecord::Migration
+  def change
+    add_column :prototypes, :user_id, :integer
+  end
+end

--- a/db/migrate/20160924144655_create_prototype_images.rb
+++ b/db/migrate/20160924144655_create_prototype_images.rb
@@ -1,0 +1,10 @@
+class CreatePrototypeImages < ActiveRecord::Migration
+  def change
+    create_table :prototype_images do |t|
+      t.integer :prototype_id
+      t.text :content
+      t.integer :role
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923054320) do
+ActiveRecord::Schema.define(version: 20160924144655) do
+
+  create_table "prototype_images", force: :cascade do |t|
+    t.integer  "prototype_id", limit: 4
+    t.text     "content",      limit: 65535
+    t.integer  "role",         limit: 4
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
 
   create_table "prototypes", force: :cascade do |t|
     t.text     "title",      limit: 65535
@@ -20,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160923054320) do
     t.text     "concept",    limit: 65535
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
+    t.integer  "user_id",    limit: 4
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
# WHAT

prototypes_controllerのnewアクションとcreateアクションの実装
# WHY

プロトタイプ投稿機能の実装
# 実装手順
1. routes.rbにcreateアクションのルーティングを記述
2. prototypes_controllerにnewアクション、createアクション、prototypes_paramsを定義
3. new.html.hamlをform_forに変更
# 期限

9/24
